### PR TITLE
Rename file pirateradio.config to pirateradio.conf

### DIFF
--- a/pirateradio.conf
+++ b/pirateradio.conf
@@ -1,0 +1,6 @@
+[pirateradio]
+frequency = 88.9
+shuffle = True
+repeat_all = True
+stereo_playback = True
+music_dir = /pirateradio


### PR DESCRIPTION
The file `pirateradio.config` was renamed to `pirateradio.conf`. 

This Pull Request fixes issue #14 .
