### PR TITLE
Remove pirateradio.config

### DIFF
--- a/pirateradio.config
+++ b/pirateradio.config
@@ -1,6 +1,0 @@
-[pirateradio]
-frequency = 88.9
-shuffle = True
-repeat_all = True
-stereo_playback = True
-music_dir = /pirateradio


### PR DESCRIPTION
I had forgotten to remove the renamed configuration file, this pull request corrects my mistake.
