### PR TITLE
Fix for Python2

### DIFF
--- a/PirateRadio.py
+++ b/PirateRadio.py
@@ -6,9 +6,9 @@ import os
 import sys
 import subprocess
 try:
-    import configparser
+	import configparser
 except:
-    import ConfigParser as configparser
+	import ConfigParser as configparser
 import re
 import random
 import threading
@@ -26,190 +26,171 @@ merge_audio_in = False
 play_stereo = True
 music_dir = "/pirateradio"
 
-music_pipe_r, music_pipe_w = os.pipe()
-microphone_pipe_r, microphone_pipe_w = os.pipe()
-
+music_pipe_r,music_pipe_w = os.pipe()
+microphone_pipe_r,microphone_pipe_w = os.pipe()
 
 def main():
-    daemonize()
-    setup()
-    files = build_file_list()
-    if repeat_all:
-        while(True):
-            play_songs(files)
-    else:
-        play_songs(files)
-    return 0
+	daemonize()
+	setup()
+	files = build_file_list()
+	if repeat_all == True:
+		while(True):
+			play_songs(files)
+	else:
+		play_songs(files)
+	return 0
+
 
 
 def build_file_list():
-    file_list = []
-    for root, folders, files in os.walk(music_dir):
-        folders.sort()
-        files.sort()
-        for filename in files:
-            if re.search(".(aac|mp3|wav|flac|m4a|ogg|pls|m3u)$",
-                         filename) is not None:
-                file_list.append(os.path.join(root, filename))
-    return file_list
+	file_list = []
+	for root, folders, files in os.walk(music_dir):
+		folders.sort()
+		files.sort()
+		for filename in files:
+			if re.search(".(aac|mp3|wav|flac|m4a|ogg|pls|m3u)$", filename) != None: 
+				file_list.append(os.path.join(root, filename))
+	return file_list
+
 
 
 def play_songs(file_list):
-    print("Playing songs to frequency ", str(frequency))
-    print("Shuffle is " + on_off[shuffle])
-    print("Repeat All is " + on_off[repeat_all])
-    # print("Stereo playback is " + on_off[play_stereo])
+	print("Playing songs to frequency ", str(frequency))
+	print("Shuffle is " + on_off[shuffle])
+	print("Repeat All is " + on_off[repeat_all])
+	# print("Stereo playback is " + on_off[play_stereo])
+	
+	if shuffle == True:
+		random.shuffle(file_list)
+	with open(os.devnull, "w") as dev_null:
+		for filename in file_list:
+			print("Playing ",filename)
+			if re.search(".pls$", filename) != None:
+				streamurl = parse_pls(filename, 1)
+				if streamurl != None:
+					print("streaming radio from " + streamurl)
+					subprocess.call(["ffmpeg","-i",streamurl,"-f","s16le","-acodec","pcm_s16le","-ac", "2" if play_stereo else "1" ,"-ar","44100","-"],stdout=music_pipe_w, stderr=dev_null)
+			elif re.search(".m3u$", filename) != None:
+				streamurl = parse_m3u(filename, 1)
+				if streamurl != None:
+					print("streaming radio from " + streamurl)
+					subprocess.call(["ffmpeg","-i",streamurl,"-f","s16le","-acodec","pcm_s16le","-ac", "2" if play_stereo else "1" ,"-ar","44100","-"],stdout=music_pipe_w, stderr=dev_null)
+			else:
+				subprocess.call(["ffmpeg","-i",filename,"-f","s16le","-acodec","pcm_s16le","-ac", "2" if play_stereo else "1" ,"-ar","44100","-"],stdout=music_pipe_w, stderr=dev_null)
 
-    if shuffle:
-        random.shuffle(file_list)
-    with open(os.devnull, "w") as dev_null:
-        for filename in file_list:
-            print("Playing ", filename)
-            if re.search(".pls$", filename) is not None:
-                streamurl = parse_pls(filename, 1)
-                if streamurl is not None:
-                    print("streaming radio from " + streamurl)
-                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
-                                     "-acodec", "pcm_s16le", "-ac",
-                                     "2" if play_stereo else "1", "-ar",
-                                     "44100", "-"], stdout=music_pipe_w,
-                                    stderr=dev_null)
-            elif re.search(".m3u$", filename) is not None:
-                streamurl = parse_m3u(filename, 1)
-                if streamurl is not None:
-                    print("streaming radio from " + streamurl)
-                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
-                                     "-acodec", "pcm_s16le", "-ac",
-                                     "2" if play_stereo else "1", "-ar",
-                                     "44100", "-"], stdout=music_pipe_w,
-                                    stderr=dev_null)
-            else:
-                subprocess.call(["ffmpeg", "-i", filename, "-f", "s16le",
-                                 "-acodec", "pcm_s16le", "-ac",
-                                 "2" if play_stereo else "1", "-ar", "44100",
-                                 "-"], stdout=music_pipe_w, stderr=dev_null)
 
 
 def read_config():
-    global frequency
-    global shuffle
-    global repeat_all
-    global play_stereo
-    global music_dir
-    try:
-        config = configparser.ConfigParser()
-        config.read(config_location)
-
-    except:
-        print("Error reading from config file.")
-    else:
+	global frequency
+	global shuffle
+	global repeat_all
+	global play_stereo
+	global music_dir
+	try:
+		config = configparser.ConfigParser()
+		config.read(config_location)
+		
+	except:
+		print("Error reading from config file.")
+	else:
         # This resembles the fallback argument, not present in python 2
-        try:
-            play_stereo = config.get("pirateradio", 'stereo_playback')
-        except:
-            pass
-        try:
-            frequency = config.get("pirateradio", 'frequency')
-        except:
-            pass
-        try:
-            shuffle = config.getboolean("pirateradio", 'shuffle')
-        except:
-            pass
-        try:
-            repeat_all = config.getboolean("pirateradio", 'repeat_all')
-        except:
-            pass
-        try:
-            music_dir = config.get("pirateradio", 'music_dir')
-        except:
-            pass
-
+		try:
+			play_stereo = config.get("pirateradio", 'stereo_playback')
+		except:
+			pass
+		try:
+			frequency = config.get("pirateradio",'frequency')
+		except:
+			pass
+		try:
+			shuffle = config.getboolean("pirateradio",'shuffle')
+		except:
+			pass
+		try:
+			repeat_all = config.getboolean("pirateradio",'repeat_all')
+		except:
+			pass
+		try:
+			music_dir = config.get("pirateradio", 'music_dir')
+		except:
+			pass
 
 def parse_pls(src, titleindex):
-    # breaking up the pls file in separate strings
-    lines = []
-    with open(src, "r") as f:
-        lines = f.readlines()
+	# breaking up the pls file in separate strings
+	lines = []
+	with open( src, "r" ) as f:
+		lines = f.readlines()
 
-    # and parse the lines
-    if lines is not None:
-        for line in lines:
-            # search for the URI
-            match = re.match("^[ \\t]*file" + str(titleindex) +
-                             "[ \\t]*=[ \\t]*(.*$)", line, flags=re.IGNORECASE)
-            if match is not None:
-                if match.group(1) is not None:
-                    # URI found, it's saved in the second match group
-                    # output the URI to the destination file
-                    return match.group(1)
-
-    return None
-
-
+	# and parse the lines
+	if lines != None:
+		for line in lines:
+			# search for the URI
+			match = re.match( "^[ \\t]*file" + str(titleindex) + "[ \\t]*=[ \\t]*(.*$)", line, flags=re.IGNORECASE )
+			if match != None:
+				if match.group( 1 ) != None:
+				# URI found, it's saved in the second match group
+				# output the URI to the destination file
+					return match.group( 1 )
+		
+	return None
+		
 def parse_m3u(src, titleindex):
-    # create a list of strings, one per line in the source file
-    lines = []
-    searchindex = int(1)
-    with open(src, "r") as f:
-        lines = f.readlines()
+	# create a list of strings, one per line in the source file
+	lines = []
+	searchindex = int(1)
+	with open( src, "r" ) as f:
+  		  lines = f.readlines()
 
-    if lines is not None:
-        for line in lines:
-            # search for the URI
-            if '://' in line:
-                if searchindex == titleindex:
-                    return line
-                else:
-                    searchindex += 1
-
-    return None
-
+	if lines != None:
+		for line in lines:
+		# search for the URI
+			if '://' in line:
+				if searchindex == titleindex:
+					return line
+				else:
+					searchindex += 1
+		
+	return None
+			
+	
 
 def daemonize():
-    fpid = os.fork()
-    if fpid != 0:
-        sys.exit(0)
+	fpid=os.fork()
+	if fpid!=0:
+		sys.exit(0)
 
 
 def setup():
-    # threading.Thread(target = open_microphone).start()
+	#threading.Thread(target = open_microphone).start()
 
-    global frequency
-    read_config()
-    # open_microphone()
-    run_pifm()
+	global frequency
+	read_config()
+	# open_microphone()
+	run_pifm()
 
 
 def run_pifm(use_audio_in=False):
-    global fm_process
-    with open(os.devnull, "w") as dev_null:
-        fm_process = subprocess.Popen(["/root/pifm", "-", str(frequency),
-                                       "44100", "stereo" if play_stereo
-                                       else "mono"], stdin=music_pipe_r,
-                                      stdout=dev_null)
+	global fm_process
+	with open(os.devnull, "w") as dev_null:
+		fm_process = subprocess.Popen(["/root/pifm","-",str(frequency),"44100", "stereo" if play_stereo else "mono"], stdin=music_pipe_r, stdout=dev_null)
 
-        # if use_audio_in == False:
-        # else:
-        #   fm_process = subprocess.Popen(["/root/pifm2", "-", str(frequency),
-        #                                  "44100"], stdin=microphone_pipe_r,
-        #                                 stdout=dev_null)
-
+		#if use_audio_in == False:
+		#else:
+		#	fm_process = subprocess.Popen(["/root/pifm2","-",str(frequency),"44100"], stdin=microphone_pipe_r, stdout=dev_null)
 
 def record_audio_input():
-    return subprocess.Popen(["arecord", "-fS16_LE", "--buffer-time=50000",
-                             "-r", "44100", "-Dplughw:1,0", "-"],
-                            stdout=microphone_pipe_w)
-
+	return subprocess.Popen(["arecord", "-fS16_LE", "--buffer-time=50000", "-r", "44100", "-Dplughw:1,0", "-"], stdout=microphone_pipe_w)
 
 def open_microphone():
-    global fm_process
-    audio_process = None
-    if os.path.exists("/proc/asound/card1"):
-        audio_process = record_audio_input()
-        run_pifm(merge_audio_in)
-    else:
-        run_pifm()
+	global fm_process
+	audio_process = None
+	if os.path.exists("/proc/asound/card1"):
+		audio_process = record_audio_input()
+		run_pifm(merge_audio_in)
+	else:
+		run_pifm()
+
 
 
 main()
+

--- a/PirateRadio.py
+++ b/PirateRadio.py
@@ -58,7 +58,7 @@ def build_file_list():
 
 
 def play_songs(file_list):
-    print("Playing songs to frequency ", str(frequency))
+    print("Playing songs to frequency {0}".format(str(frequency)))
     print("Shuffle is " + on_off[shuffle])
     print("Repeat All is " + on_off[repeat_all])
     # print("Stereo playback is " + on_off[play_stereo])
@@ -67,7 +67,7 @@ def play_songs(file_list):
         random.shuffle(file_list)
     with open(os.devnull, "w") as dev_null:
         for filename in file_list:
-            print("Playing ", filename)
+            print("Playing {0}".format(filename))
             global ffmpeg
             if re.search(".pls$", filename) is not None:
                 streamurl = parse_pls(filename, 1)

--- a/PirateRadio.py
+++ b/PirateRadio.py
@@ -13,6 +13,8 @@ import re
 import random
 import threading
 import time
+import signal
+import RPi.GPIO as gpio
 
 
 fm_process = None
@@ -32,6 +34,7 @@ microphone_pipe_r, microphone_pipe_w = os.pipe()
 
 def main():
     daemonize()
+    print("To stop run 'kill -15 {0}'".format(os.getpid()))
     setup()
     files = build_file_list()
     if repeat_all:
@@ -65,29 +68,34 @@ def play_songs(file_list):
     with open(os.devnull, "w") as dev_null:
         for filename in file_list:
             print("Playing ", filename)
+            global ffmpeg
             if re.search(".pls$", filename) is not None:
                 streamurl = parse_pls(filename, 1)
                 if streamurl is not None:
                     print("streaming radio from " + streamurl)
-                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
-                                     "-acodec", "pcm_s16le", "-ac",
-                                     "2" if play_stereo else "1", "-ar",
-                                     "44100", "-"], stdout=music_pipe_w,
-                                    stderr=dev_null)
+                    ffmpeg = subprocess.Popen(["ffmpeg", "-i", streamurl, "-f",
+                                               "s16le", "-acodec", "pcm_s16le",
+                                               "-ar", "44100", "-ac",
+                                               "2" if play_stereo else "1",
+                                               "-"], stdout=music_pipe_w,
+                                              stderr=dev_null)
             elif re.search(".m3u$", filename) is not None:
                 streamurl = parse_m3u(filename, 1)
                 if streamurl is not None:
                     print("streaming radio from " + streamurl)
-                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
-                                     "-acodec", "pcm_s16le", "-ac",
-                                     "2" if play_stereo else "1", "-ar",
-                                     "44100", "-"], stdout=music_pipe_w,
-                                    stderr=dev_null)
+                    ffmpeg = subprocess.Popen(["ffmpeg", "-i", streamurl, "-f",
+                                               "s16le", "-acodec", "pcm_s16le",
+                                               "-ar", "44100", "-ac",
+                                               "2" if play_stereo else "1",
+                                               "-"], stdout=music_pipe_w,
+                                              stderr=dev_null)
             else:
-                subprocess.call(["ffmpeg", "-i", filename, "-f", "s16le",
-                                 "-acodec", "pcm_s16le", "-ac",
-                                 "2" if play_stereo else "1", "-ar", "44100",
-                                 "-"], stdout=music_pipe_w, stderr=dev_null)
+                ffmpeg = subprocess.Popen(["ffmpeg", "-i", filename, "-f",
+                                           "s16le", "-acodec", "pcm_s16le",
+                                           "-ac", "2" if play_stereo else "1",
+                                           "-ar", "44100", "-"],
+                                          stdout=music_pipe_w, stderr=dev_null)
+            ffmpeg.wait()
 
 
 def read_config():
@@ -212,4 +220,17 @@ def open_microphone():
         run_pifm()
 
 
+def terminate(signum, frame):
+    # This will stop the transmission not just silencing it
+    gpio.setmode(gpio.BOARD)
+    gpio.setwarnings(False)
+    gpio.setup(7, gpio.OUT)
+    gpio.cleanup()
+
+    fm_process.terminate()  # Stop pifm
+    ffmpeg.kill()  # Stop ffmpeg. Terminate() didn't always work
+    sys.exit()
+
+
+signal.signal(signal.SIGTERM, terminate)
 main()

--- a/PirateRadio.py
+++ b/PirateRadio.py
@@ -13,8 +13,6 @@ import re
 import random
 import threading
 import time
-import signal
-import RPi.GPIO as gpio
 
 
 fm_process = None
@@ -34,7 +32,6 @@ microphone_pipe_r, microphone_pipe_w = os.pipe()
 
 def main():
     daemonize()
-    print("To stop run 'kill -15 {0}'".format(os.getpid()))
     setup()
     files = build_file_list()
     if repeat_all:
@@ -68,34 +65,29 @@ def play_songs(file_list):
     with open(os.devnull, "w") as dev_null:
         for filename in file_list:
             print("Playing ", filename)
-            global ffmpeg
             if re.search(".pls$", filename) is not None:
                 streamurl = parse_pls(filename, 1)
                 if streamurl is not None:
                     print("streaming radio from " + streamurl)
-                    ffmpeg = subprocess.Popen(["ffmpeg", "-i", streamurl, "-f",
-                                               "s16le", "-acodec", "pcm_s16le",
-                                               "-ar", "44100", "-ac",
-                                               "2" if play_stereo else "1",
-                                               "-"], stdout=music_pipe_w,
-                                              stderr=dev_null)
+                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
+                                     "-acodec", "pcm_s16le", "-ac",
+                                     "2" if play_stereo else "1", "-ar",
+                                     "44100", "-"], stdout=music_pipe_w,
+                                    stderr=dev_null)
             elif re.search(".m3u$", filename) is not None:
                 streamurl = parse_m3u(filename, 1)
                 if streamurl is not None:
                     print("streaming radio from " + streamurl)
-                    ffmpeg = subprocess.Popen(["ffmpeg", "-i", streamurl, "-f",
-                                               "s16le", "-acodec", "pcm_s16le",
-                                               "-ar", "44100", "-ac",
-                                               "2" if play_stereo else "1",
-                                               "-"], stdout=music_pipe_w,
-                                              stderr=dev_null)
+                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
+                                     "-acodec", "pcm_s16le", "-ac",
+                                     "2" if play_stereo else "1", "-ar",
+                                     "44100", "-"], stdout=music_pipe_w,
+                                    stderr=dev_null)
             else:
-                ffmpeg = subprocess.Popen(["ffmpeg", "-i", filename, "-f",
-                                           "s16le", "-acodec", "pcm_s16le",
-                                           "-ac", "2" if play_stereo else "1",
-                                           "-ar", "44100", "-"],
-                                          stdout=music_pipe_w, stderr=dev_null)
-            ffmpeg.wait()
+                subprocess.call(["ffmpeg", "-i", filename, "-f", "s16le",
+                                 "-acodec", "pcm_s16le", "-ac",
+                                 "2" if play_stereo else "1", "-ar", "44100",
+                                 "-"], stdout=music_pipe_w, stderr=dev_null)
 
 
 def read_config():
@@ -220,17 +212,4 @@ def open_microphone():
         run_pifm()
 
 
-def terminate(signum, frame):
-    # This will stop the transmission not just silencing it
-    gpio.setmode(gpio.BOARD)
-    gpio.setwarnings(False)
-    gpio.setup(7, gpio.OUT)
-    gpio.cleanup()
-
-    fm_process.terminate()  # Stop pifm
-    ffmpeg.kill()  # Stop ffmpeg. Terminate() didn't always work
-    sys.exit()
-
-
-signal.signal(signal.SIGTERM, terminate)
 main()

--- a/PirateRadio.py
+++ b/PirateRadio.py
@@ -2,19 +2,18 @@
 # Pirate Radio
 # Author: Wynter Woods (Make Magazine)
 
-try:	# the following tests for a python3.x module
+import os
+import sys
+import subprocess
+try:
 	import configparser
-except: # if the module isn't found, we're likely running python2.x and will just trick it into working
+except:
 	import ConfigParser as configparser
-finally:
-	import re
-	import re
-	import random
-	import sys
-	import os
-	import threading
-	import time
-	import subprocess
+import re
+import random
+import threading
+import time
+
 
 fm_process = None
 on_off = ["off", "on"]
@@ -94,11 +93,27 @@ def read_config():
 	except:
 		print("Error reading from config file.")
 	else:
-		play_stereo = config.get("pirateradio", 'stereo_playback', fallback=True)
-		frequency = config.get("pirateradio",'frequency')
-		shuffle = config.getboolean("pirateradio",'shuffle',fallback=False)
-		repeat_all = config.getboolean("pirateradio",'repeat_all', fallback=False)
-		music_dir = config.get("pirateradio", 'music_dir', fallback="/pirateradio")
+        # This resembles the fallback argument, not present in python 2
+		try:
+			play_stereo = config.get("pirateradio", 'stereo_playback')
+		except:
+			pass
+		try:
+			frequency = config.get("pirateradio",'frequency')
+		except:
+			pass
+		try:
+			shuffle = config.getboolean("pirateradio",'shuffle')
+		except:
+			pass
+		try:
+			repeat_all = config.getboolean("pirateradio",'repeat_all')
+		except:
+			pass
+		try:
+			music_dir = config.get("pirateradio", 'music_dir')
+		except:
+			pass
 
 def parse_pls(src, titleindex):
 	# breaking up the pls file in separate strings

--- a/PirateRadio.py
+++ b/PirateRadio.py
@@ -58,7 +58,7 @@ def build_file_list():
 
 
 def play_songs(file_list):
-    print("Playing songs to frequency {0}".format(str(frequency)))
+    print("Playing songs to frequency ", str(frequency))
     print("Shuffle is " + on_off[shuffle])
     print("Repeat All is " + on_off[repeat_all])
     # print("Stereo playback is " + on_off[play_stereo])
@@ -67,7 +67,7 @@ def play_songs(file_list):
         random.shuffle(file_list)
     with open(os.devnull, "w") as dev_null:
         for filename in file_list:
-            print("Playing {0}".format(filename))
+            print("Playing ", filename)
             global ffmpeg
             if re.search(".pls$", filename) is not None:
                 streamurl = parse_pls(filename, 1)

--- a/PirateRadio.py
+++ b/PirateRadio.py
@@ -6,9 +6,9 @@ import os
 import sys
 import subprocess
 try:
-	import configparser
+    import configparser
 except:
-	import ConfigParser as configparser
+    import ConfigParser as configparser
 import re
 import random
 import threading
@@ -26,171 +26,190 @@ merge_audio_in = False
 play_stereo = True
 music_dir = "/pirateradio"
 
-music_pipe_r,music_pipe_w = os.pipe()
-microphone_pipe_r,microphone_pipe_w = os.pipe()
+music_pipe_r, music_pipe_w = os.pipe()
+microphone_pipe_r, microphone_pipe_w = os.pipe()
+
 
 def main():
-	daemonize()
-	setup()
-	files = build_file_list()
-	if repeat_all == True:
-		while(True):
-			play_songs(files)
-	else:
-		play_songs(files)
-	return 0
-
+    daemonize()
+    setup()
+    files = build_file_list()
+    if repeat_all:
+        while(True):
+            play_songs(files)
+    else:
+        play_songs(files)
+    return 0
 
 
 def build_file_list():
-	file_list = []
-	for root, folders, files in os.walk(music_dir):
-		folders.sort()
-		files.sort()
-		for filename in files:
-			if re.search(".(aac|mp3|wav|flac|m4a|ogg|pls|m3u)$", filename) != None: 
-				file_list.append(os.path.join(root, filename))
-	return file_list
-
+    file_list = []
+    for root, folders, files in os.walk(music_dir):
+        folders.sort()
+        files.sort()
+        for filename in files:
+            if re.search(".(aac|mp3|wav|flac|m4a|ogg|pls|m3u)$",
+                         filename) is not None:
+                file_list.append(os.path.join(root, filename))
+    return file_list
 
 
 def play_songs(file_list):
-	print("Playing songs to frequency ", str(frequency))
-	print("Shuffle is " + on_off[shuffle])
-	print("Repeat All is " + on_off[repeat_all])
-	# print("Stereo playback is " + on_off[play_stereo])
-	
-	if shuffle == True:
-		random.shuffle(file_list)
-	with open(os.devnull, "w") as dev_null:
-		for filename in file_list:
-			print("Playing ",filename)
-			if re.search(".pls$", filename) != None:
-				streamurl = parse_pls(filename, 1)
-				if streamurl != None:
-					print("streaming radio from " + streamurl)
-					subprocess.call(["ffmpeg","-i",streamurl,"-f","s16le","-acodec","pcm_s16le","-ac", "2" if play_stereo else "1" ,"-ar","44100","-"],stdout=music_pipe_w, stderr=dev_null)
-			elif re.search(".m3u$", filename) != None:
-				streamurl = parse_m3u(filename, 1)
-				if streamurl != None:
-					print("streaming radio from " + streamurl)
-					subprocess.call(["ffmpeg","-i",streamurl,"-f","s16le","-acodec","pcm_s16le","-ac", "2" if play_stereo else "1" ,"-ar","44100","-"],stdout=music_pipe_w, stderr=dev_null)
-			else:
-				subprocess.call(["ffmpeg","-i",filename,"-f","s16le","-acodec","pcm_s16le","-ac", "2" if play_stereo else "1" ,"-ar","44100","-"],stdout=music_pipe_w, stderr=dev_null)
+    print("Playing songs to frequency ", str(frequency))
+    print("Shuffle is " + on_off[shuffle])
+    print("Repeat All is " + on_off[repeat_all])
+    # print("Stereo playback is " + on_off[play_stereo])
 
+    if shuffle:
+        random.shuffle(file_list)
+    with open(os.devnull, "w") as dev_null:
+        for filename in file_list:
+            print("Playing ", filename)
+            if re.search(".pls$", filename) is not None:
+                streamurl = parse_pls(filename, 1)
+                if streamurl is not None:
+                    print("streaming radio from " + streamurl)
+                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
+                                     "-acodec", "pcm_s16le", "-ac",
+                                     "2" if play_stereo else "1", "-ar",
+                                     "44100", "-"], stdout=music_pipe_w,
+                                    stderr=dev_null)
+            elif re.search(".m3u$", filename) is not None:
+                streamurl = parse_m3u(filename, 1)
+                if streamurl is not None:
+                    print("streaming radio from " + streamurl)
+                    subprocess.call(["ffmpeg", "-i", streamurl, "-f", "s16le",
+                                     "-acodec", "pcm_s16le", "-ac",
+                                     "2" if play_stereo else "1", "-ar",
+                                     "44100", "-"], stdout=music_pipe_w,
+                                    stderr=dev_null)
+            else:
+                subprocess.call(["ffmpeg", "-i", filename, "-f", "s16le",
+                                 "-acodec", "pcm_s16le", "-ac",
+                                 "2" if play_stereo else "1", "-ar", "44100",
+                                 "-"], stdout=music_pipe_w, stderr=dev_null)
 
 
 def read_config():
-	global frequency
-	global shuffle
-	global repeat_all
-	global play_stereo
-	global music_dir
-	try:
-		config = configparser.ConfigParser()
-		config.read(config_location)
-		
-	except:
-		print("Error reading from config file.")
-	else:
+    global frequency
+    global shuffle
+    global repeat_all
+    global play_stereo
+    global music_dir
+    try:
+        config = configparser.ConfigParser()
+        config.read(config_location)
+
+    except:
+        print("Error reading from config file.")
+    else:
         # This resembles the fallback argument, not present in python 2
-		try:
-			play_stereo = config.get("pirateradio", 'stereo_playback')
-		except:
-			pass
-		try:
-			frequency = config.get("pirateradio",'frequency')
-		except:
-			pass
-		try:
-			shuffle = config.getboolean("pirateradio",'shuffle')
-		except:
-			pass
-		try:
-			repeat_all = config.getboolean("pirateradio",'repeat_all')
-		except:
-			pass
-		try:
-			music_dir = config.get("pirateradio", 'music_dir')
-		except:
-			pass
+        try:
+            play_stereo = config.get("pirateradio", 'stereo_playback')
+        except:
+            pass
+        try:
+            frequency = config.get("pirateradio", 'frequency')
+        except:
+            pass
+        try:
+            shuffle = config.getboolean("pirateradio", 'shuffle')
+        except:
+            pass
+        try:
+            repeat_all = config.getboolean("pirateradio", 'repeat_all')
+        except:
+            pass
+        try:
+            music_dir = config.get("pirateradio", 'music_dir')
+        except:
+            pass
+
 
 def parse_pls(src, titleindex):
-	# breaking up the pls file in separate strings
-	lines = []
-	with open( src, "r" ) as f:
-		lines = f.readlines()
+    # breaking up the pls file in separate strings
+    lines = []
+    with open(src, "r") as f:
+        lines = f.readlines()
 
-	# and parse the lines
-	if lines != None:
-		for line in lines:
-			# search for the URI
-			match = re.match( "^[ \\t]*file" + str(titleindex) + "[ \\t]*=[ \\t]*(.*$)", line, flags=re.IGNORECASE )
-			if match != None:
-				if match.group( 1 ) != None:
-				# URI found, it's saved in the second match group
-				# output the URI to the destination file
-					return match.group( 1 )
-		
-	return None
-		
+    # and parse the lines
+    if lines is not None:
+        for line in lines:
+            # search for the URI
+            match = re.match("^[ \\t]*file" + str(titleindex) +
+                             "[ \\t]*=[ \\t]*(.*$)", line, flags=re.IGNORECASE)
+            if match is not None:
+                if match.group(1) is not None:
+                    # URI found, it's saved in the second match group
+                    # output the URI to the destination file
+                    return match.group(1)
+
+    return None
+
+
 def parse_m3u(src, titleindex):
-	# create a list of strings, one per line in the source file
-	lines = []
-	searchindex = int(1)
-	with open( src, "r" ) as f:
-  		  lines = f.readlines()
+    # create a list of strings, one per line in the source file
+    lines = []
+    searchindex = int(1)
+    with open(src, "r") as f:
+        lines = f.readlines()
 
-	if lines != None:
-		for line in lines:
-		# search for the URI
-			if '://' in line:
-				if searchindex == titleindex:
-					return line
-				else:
-					searchindex += 1
-		
-	return None
-			
-	
+    if lines is not None:
+        for line in lines:
+            # search for the URI
+            if '://' in line:
+                if searchindex == titleindex:
+                    return line
+                else:
+                    searchindex += 1
+
+    return None
+
 
 def daemonize():
-	fpid=os.fork()
-	if fpid!=0:
-		sys.exit(0)
+    fpid = os.fork()
+    if fpid != 0:
+        sys.exit(0)
 
 
 def setup():
-	#threading.Thread(target = open_microphone).start()
+    # threading.Thread(target = open_microphone).start()
 
-	global frequency
-	read_config()
-	# open_microphone()
-	run_pifm()
+    global frequency
+    read_config()
+    # open_microphone()
+    run_pifm()
 
 
 def run_pifm(use_audio_in=False):
-	global fm_process
-	with open(os.devnull, "w") as dev_null:
-		fm_process = subprocess.Popen(["/root/pifm","-",str(frequency),"44100", "stereo" if play_stereo else "mono"], stdin=music_pipe_r, stdout=dev_null)
+    global fm_process
+    with open(os.devnull, "w") as dev_null:
+        fm_process = subprocess.Popen(["/root/pifm", "-", str(frequency),
+                                       "44100", "stereo" if play_stereo
+                                       else "mono"], stdin=music_pipe_r,
+                                      stdout=dev_null)
 
-		#if use_audio_in == False:
-		#else:
-		#	fm_process = subprocess.Popen(["/root/pifm2","-",str(frequency),"44100"], stdin=microphone_pipe_r, stdout=dev_null)
+        # if use_audio_in == False:
+        # else:
+        #   fm_process = subprocess.Popen(["/root/pifm2", "-", str(frequency),
+        #                                  "44100"], stdin=microphone_pipe_r,
+        #                                 stdout=dev_null)
+
 
 def record_audio_input():
-	return subprocess.Popen(["arecord", "-fS16_LE", "--buffer-time=50000", "-r", "44100", "-Dplughw:1,0", "-"], stdout=microphone_pipe_w)
+    return subprocess.Popen(["arecord", "-fS16_LE", "--buffer-time=50000",
+                             "-r", "44100", "-Dplughw:1,0", "-"],
+                            stdout=microphone_pipe_w)
+
 
 def open_microphone():
-	global fm_process
-	audio_process = None
-	if os.path.exists("/proc/asound/card1"):
-		audio_process = record_audio_input()
-		run_pifm(merge_audio_in)
-	else:
-		run_pifm()
-
+    global fm_process
+    audio_process = None
+    if os.path.exists("/proc/asound/card1"):
+        audio_process = record_audio_input()
+        run_pifm(merge_audio_in)
+    else:
+        run_pifm()
 
 
 main()
-


### PR DESCRIPTION
It really solves the issue that you tried to fix with last commit as the fallback argument is not present in Python2 (tested in 2.7.3 installed from stable repositories), as it was said in bug #13 

As I am not very experienced in programming I'd like you to have a look at the work around I've used to resemble the fallback argument. What I tried to do there is to try to read the config and if it fails (because it isn't present or it is properly written) it keeps the defaults that are set at the beginning of the script.

I think I've made a bit of an unnecessary mess at the beginning because I didn't keep the finally clause, but it's just because I wrote this before your last commit was published :/ If you prefer it that way I can leave it as it was.
